### PR TITLE
Removing link from User Management Drawer to Group Details

### DIFF
--- a/modules/nuxeo/user-group-management/designer/custom-elements/cookbook-user-management-drawer.html
+++ b/modules/nuxeo/user-group-management/designer/custom-elements/cookbook-user-management-drawer.html
@@ -28,7 +28,7 @@
       
       	<div class="content">
           <template is="dom-repeat" items="[[adminGroupsOfUser]]" as="group">
-            	<div class="list-item"><a href="#!/admin/user-group-management/group/[[group]]">[[group]]</a></div>
+            	<div class="list-item">[[group]]</div>
           </template>
       </div>
 


### PR DESCRIPTION
in User/Group Management as there is no way for user to get back.

Change requested by Randy Rowles.