### PR TITLE
Patch 1

### DIFF
--- a/modules/nuxeo/related-documents/modeler/getAllRelations.js
+++ b/modules/nuxeo/related-documents/modeler/getAllRelations.js
@@ -74,7 +74,9 @@ function run(input, params) {
 
           relDocs = [];
           var numRelDocs = docs.length;
-
+          var originLabel = "";
+          var lastIndex = "";
+          var inverseLabel = "";
           Console.log(numRelDocs + " related docs FOUND for predicate (id): " + predicate.id );
 
           for(k=0; k<numRelDocs; k++){
@@ -86,7 +88,17 @@ function run(input, params) {
 
             relDoc.incoming = incoming;
             relDoc.relationId = predicate.id;
-            relDoc.relationLabel = predicate.label;
+            if(incoming) {
+				   relDoc.relationLabel = predicate.label;
+			   }
+			   else {
+               // if outgoing : replace the last occurence of . by .inverse. to properly show the relation label
+               // exemple "label.relation.predicate.References" becomes "label.relation.predicate.inverse.References"
+				   originLabel = predicate.label;
+				   lastIndex = originLabel.lastIndexOf('.');
+				   inverseLabel = originLabel.substring(0, lastIndex) + '.inverse.' + originLabel.substring(lastIndex + 1);
+				   relDoc.relationLabel = inverseLabel;
+			   }
             relDocs.push(relDoc);
           }
 

--- a/modules/nuxeo/related-documents/modeler/getAllRelations.js
+++ b/modules/nuxeo/related-documents/modeler/getAllRelations.js
@@ -77,6 +77,7 @@ function run(input, params) {
           var originLabel = "";
           var lastIndex = "";
           var inverseLabel = "";
+
           Console.log(numRelDocs + " related docs FOUND for predicate (id): " + predicate.id );
 
           for(k=0; k<numRelDocs; k++){

--- a/modules/nuxeo/related-documents/modeler/getAllRelations.js
+++ b/modules/nuxeo/related-documents/modeler/getAllRelations.js
@@ -89,16 +89,16 @@ function run(input, params) {
             relDoc.incoming = incoming;
             relDoc.relationId = predicate.id;
             if(incoming) {
-				   relDoc.relationLabel = predicate.label;
-			   }
-			   else {
-               // if outgoing : replace the last occurence of . by .inverse. to properly show the relation label
-               // exemple "label.relation.predicate.References" becomes "label.relation.predicate.inverse.References"
-				   originLabel = predicate.label;
-				   lastIndex = originLabel.lastIndexOf('.');
-				   inverseLabel = originLabel.substring(0, lastIndex) + '.inverse.' + originLabel.substring(lastIndex + 1);
-				   relDoc.relationLabel = inverseLabel;
-			   }
+              relDoc.relationLabel = predicate.label;
+            }
+            else {
+              // if outgoing : replace the last occurence of . by .inverse. to properly show the relation label
+              // exemple "label.relation.predicate.References" becomes "label.relation.predicate.inverse.References"
+              originLabel = predicate.label;
+              lastIndex = originLabel.lastIndexOf('.');
+              inverseLabel = originLabel.substring(0, lastIndex) + '.inverse.' + originLabel.substring(lastIndex + 1);
+              relDoc.relationLabel = inverseLabel;
+            }
             relDocs.push(relDoc);
           }
 


### PR DESCRIPTION
if one creates a relation A -> B, we want the inverse label when showing B -> A
example :  if A "label.relation.predicate.References", then B "label.relation.predicate.inverse.References" A
